### PR TITLE
Update HomeAssistant documentation - Add switch, media player, and cover device support

### DIFF
--- a/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
+++ b/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
@@ -4,7 +4,8 @@ Home Assistant Driver
 =====================
 
 The Home Assistant driver enables VOLTTRON to read any data point from any Home Assistant controlled device.
-Currently control(write access) is supported only for lights(state and brightness) and thermostats(state and temperature).
+Currently control (write access) is supported for lights (state and brightness), thermostats (state and temperature), 
+switches, media players, and covers.
 
 The following diagram shows interaction between platform driver agent and home assistant driver.
 
@@ -29,6 +30,37 @@ Clone the repository, start volttron, install the listener agent, and the platfo
 - `Listener agent <https://volttron.readthedocs.io/en/main/introduction/platform-install.html#installing-and-running-agents>`_
 - `Platform driver agent <https://volttron.readthedocs.io/en/main/agent-framework/core-service-agents/platform-driver/platform-driver-agent.html?highlight=platform%20driver%20isntall#configuring-the-platform-driver>`_
 
+Supported Device Types
+----------------------
+
+The Home Assistant driver supports the following device types with write access:
+
+**Lights**
+  - Control state (on/off)
+  - Control brightness (0-255)
+  - Control RGB color
+
+**Thermostats (Climate)**
+  - Control state (off/heat/cool/auto)
+  - Set target temperature
+
+**Input Boolean**
+  - Toggle state
+
+**Switches**
+  - Turn on/off
+
+**Media Players**
+  - Control playback (play/pause/stop)
+  - Set volume level
+  - Navigate tracks (next/previous)
+
+**Covers**
+  - Open/close
+  - Set position (0-100)
+
+All Home Assistant controlled devices support read access for their states and attributes.
+
 Configuration
 --------------
 
@@ -36,7 +68,7 @@ After cloning, generate configuration files. Each device requires one device con
 Ensure your registry_config parameter in your device configuration file, links to correct registry config name in the
 config store. For more details on how volttron platform driver agent works with volttron configuration store see,
 `Platform driver configuration <https://volttron.readthedocs.io/en/main/agent-framework/driver-framework/platform-driver/platform-driver.html#configuration-and-installation>`_
-Examples for lights and thermostats are provided below.
+Examples for lights, thermostats, switches, media players, and covers are provided below.
 
 Device configuration
 ++++++++++++++++++++
@@ -62,9 +94,7 @@ Registry Configuration
 
 Registry file can contain one single device and its attributes or a logical group of devices and its
 attributes. Each entry should include the full entity id of the device, including but not limited to home assistant provided prefix
-such as "light.",  "climate." etc. The driver uses these prefixes to convert states into integers.
-Like mentioned before, the driver can only control lights and thermostats but can get data from all devices
-controlled by home assistant
+such as "light.", "climate.", "switch.", "media_player.", "cover.", etc. The driver uses these prefixes to convert states into integers.
 
 Each entry in a registry file should also have a 'Entity Point' and a unique value for 'Volttron Point Name'. The 'Entity ID' maps to the device instance, the 'Entity Point' extracts the attribute or state, and 'Volttron Point Name' determines the name of that point as it appears in VOLTTRON.
 
@@ -73,9 +103,11 @@ Attributes can be located in the developer tools in the Home Assistant GUI.
 .. image:: home-assistant.png
 
 
+Example Light Registry
+**********************
+
 Below is an example file named light.example.json which has attributes of a single light instance with entity
 id 'light.example':
-
 
 .. code-block:: json
 
@@ -116,7 +148,7 @@ have "Volttron Point Name" as 'light1/brightness' and 'light2/brightness' respec
 is posted to unique topic names and brightness data from light1 is not overwritten by light2 or vice-versa.
 
 Example Thermostat Registry
-***************************
+****************************
 
 For thermostats, the state is converted into numbers as follows: "0: Off, 2: heat, 3: Cool, 4: Auto",
 
@@ -158,7 +190,207 @@ For thermostats, the state is converted into numbers as follows: "0: Off, 2: hea
        }
    ]
 
+Example Switch Registry
+************************
 
+Switches support binary on/off control. The state is represented as an integer: 0 for off, 1 for on.
+
+.. code-block:: json
+
+   [
+       {
+           "Entity ID": "switch.bedroom_light",
+           "Entity Point": "state",
+           "Volttron Point Name": "switch_state",
+           "Units": "On / Off",
+           "Units Details": "0: off, 1: on",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Bedroom switch control"
+       }
+   ]
+
+**Usage Example:**
+
+.. code-block:: python
+
+   # Turn on a switch
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/switch',
+       'switch_state',
+       1
+   ).get()
+
+   # Turn off a switch
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/switch',
+       'switch_state',
+       0
+   ).get()
+
+Example Media Player Registry
+*******************************
+
+Media players support playback control, volume adjustment, and track navigation. The playback state is represented as: 
+0 for stop/off, 1 for pause, 2 for play.
+
+.. code-block:: json
+
+   [
+       {
+           "Entity ID": "media_player.living_room",
+           "Entity Point": "state",
+           "Volttron Point Name": "media_state",
+           "Units": "Enumeration",
+           "Units Details": "0: stop/off, 1: pause, 2: play",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Media player playback state"
+       },
+       {
+           "Entity ID": "media_player.living_room",
+           "Entity Point": "volume_level",
+           "Volttron Point Name": "media_volume",
+           "Units": "Percentage",
+           "Units Details": "0.0 to 1.0",
+           "Writable": true,
+           "Starting Value": 0.5,
+           "Type": "float",
+           "Notes": "Volume control"
+       },
+       {
+           "Entity ID": "media_player.living_room",
+           "Entity Point": "next_track",
+           "Volttron Point Name": "media_next",
+           "Units": "Action",
+           "Units Details": "Any value triggers action",
+           "Writable": true,
+           "Type": "int",
+           "Notes": "Skip to next track"
+       },
+       {
+           "Entity ID": "media_player.living_room",
+           "Entity Point": "previous_track",
+           "Volttron Point Name": "media_previous",
+           "Units": "Action",
+           "Units Details": "Any value triggers action",
+           "Writable": true,
+           "Type": "int",
+           "Notes": "Skip to previous track"
+       }
+   ]
+
+**Usage Example:**
+
+.. code-block:: python
+
+   # Start playback
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/media_player',
+       'media_state',
+       2  # 2 = play
+   ).get()
+
+   # Pause playback
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/media_player',
+       'media_state',
+       1  # 1 = pause
+   ).get()
+
+   # Set volume to 50%
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/media_player',
+       'media_volume',
+       0.5
+   ).get()
+
+   # Skip to next track
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/media_player',
+       'media_next',
+       1
+   ).get()
+
+Example Cover Registry
+***********************
+
+Covers (curtains, blinds, garage doors) support open/close commands and position control. The state is a string 
+("open", "closed", "opening", "closing") and position is an integer from 0 (closed) to 100 (open).
+
+.. code-block:: json
+
+   [
+       {
+           "Entity ID": "cover.garage_door",
+           "Entity Point": "state",
+           "Volttron Point Name": "cover_state",
+           "Units": "Open / Closed",
+           "Units Details": "String: open, closed, opening, closing",
+           "Writable": true,
+           "Type": "string",
+           "Notes": "Cover state control"
+       },
+       {
+           "Entity ID": "cover.garage_door",
+           "Entity Point": "current_position",
+           "Volttron Point Name": "cover_position",
+           "Units": "Percentage",
+           "Units Details": "0 to 100 (0=closed, 100=open)",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Cover position control"
+       }
+   ]
+
+**Usage Example:**
+
+.. code-block:: python
+
+   # Open cover
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/cover',
+       'cover_state',
+       'open'
+   ).get()
+
+   # Close cover
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/cover',
+       'cover_state',
+       'close'
+   ).get()
+
+   # Set position to 50%
+   agent.vip.rpc.call(
+       'platform.driver',
+       'set_point',
+       'devices/BUILDING/ROOM/cover',
+       'cover_position',
+       50
+   ).get()
+
+Storing Configuration
+++++++++++++++++++++++
 
 Transfer the registers files and the config files into the VOLTTRON config store using the commands below:
 
@@ -178,9 +410,19 @@ Upon completion, initiate the platform driver. Utilize the listener agent to ver
 
 Running Tests
 +++++++++++++++++++++++
-To run tests on the VOLTTRON home assistant driver you need to create a helper in your home assistant instance. This can be done by going to **Settings > Devices & services > Helpers > Create Helper > Toggle**. Name this new toggle **volttrontest**. After that run the pytest from the root of your VOLTTRON file.
+To run tests on the VOLTTRON home assistant driver you need to create helpers in your home assistant instance. 
+
+**Required Test Entities:**
+
+1. **Toggle Helper**: Go to **Settings > Devices & services > Helpers > Create Helper > Toggle**. Name it **volttrontest**.
+2. **Switch Entity**: A switch entity named **switch.test_switch**
+3. **Media Player Entity**: A media player entity named **media_player.test_player**
+4. **Cover Entity**: A cover entity named **cover.test_cover**
+
+After creating these entities, run the pytest from the root of your VOLTTRON directory:
 
 .. code-block:: bash
-    pytest volttron/services/core/PlatformDriverAgent/tests/test_home_assistant.py
 
-If everything works, you will see 6 passed tests.
+    pytest services/core/PlatformDriverAgent/tests/test_home_assistant.py
+
+If everything works correctly, all tests should pass, including the new integration tests for switches, media players, and covers.


### PR DESCRIPTION
# Description

Updated Home Assistant driver documentation to include write-access support for three new device types: switches, media players, and covers.

## Changes Made
- Added "Supported Device Types" section
- Added Switch device documentation with configuration example
- Added Media Player device documentation with configuration example
- Added Cover device documentation with configuration example
- Updated test requirements

Fixes # N/A (documentation update)

## Type of change
- [x] This change requires a documentation update

## How Has This Been Tested?
- [x] Verified reStructuredText syntax
- [x] Confirmed examples match implementation
- [x] Reviewed against integration tests

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Documentation corresponds to existing integration tests

**Team:** 5500-Group7  
**Author:** cristiipan (Yuzheng Pan)